### PR TITLE
Add `org-qmd--item` for checkbox format handling

### DIFF
--- a/ox-qmd.el
+++ b/ox-qmd.el
@@ -118,7 +118,7 @@ as a communication channel."
 CONTENTS is the item contents.  INFO is a plist used as
 a communication channel."
   (let ((s (org-md-item item contents info)))
-    (replace-regexp-in-string "^- +\\[X\\]" "- [x]" s)))
+    (replace-regexp-in-string "^\\([-+*] +\\)\\[X\\] " "\\1[x] " s)))
 
 
 (defun org-qmd--inner-template (contents info)

--- a/ox-qmd.el
+++ b/ox-qmd.el
@@ -71,6 +71,7 @@ When non-nil, `ox-qmd' do unfill paragraph"
               (if a (org-qmd-export-to-markdown t s v)
                 (org-open-file (org-qmd-export-to-markdown nil s v)))))))
   :translate-alist '((headline . org-qmd--headline)
+                     (item . org-qmd--item)
                      (inner-template . org-qmd--inner-template)
                      (keyword . org--qmd-keyword)
                      (strike-through . org-qmd--strike-through)
@@ -110,6 +111,14 @@ as a communication channel."
   (let* ((info (copy-sequence info))
          (info (plist-put info :with-toc nil)))
     (org-md-headline headline contents info)))
+
+
+(defun org-qmd--item (item contents info)
+  "Transcode ITEM element into Qiita Markdown format.
+CONTENTS is the item contents.  INFO is a plist used as
+a communication channel."
+  (let ((s (org-md-item item contents info)))
+    (replace-regexp-in-string "^- +\\[X\\]" "- [x]" s)))
 
 
 (defun org-qmd--inner-template (contents info)


### PR DESCRIPTION
## Background

Currently, `ox-qmd` outputs `-    [X]` for checkboxes, but Qiita Markdown only accepts `[x]` (lower `x`) as valid syntax.

## Proposed changes

Output `- [x]` for org items with checkbox `on`.

## Details

### Spaces

Note that the default bullet item filter ([`org-md-item`](https://github.com/bzg/org-mode/blob/def8e57c18b7a875c4a367d4a29d82b27e67ce16/lisp/ox-md.el#L461)) outputs a bit strange or verbose Markdown.

For example, the following org source:

```org
- [X] Item
```

.. is exported as this Markdown:

```md
-    [X] Item
```

> The four spaces between `-` and `[X]` was surprising to me.

### Numbered checkbox

Qiita also converts `1. [x] A` into checkbox, but I think it's basically a mistake of `- [x] A`.

I did not consider such numbered checkbox in this PR.
